### PR TITLE
Add missing index file

### DIFF
--- a/pre-v2.0-3e65111/index.html
+++ b/pre-v2.0-3e65111/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv=refresh content=0;url=sc_service/index.html>


### PR DESCRIPTION
This PR adds an index file to the pre-v2.0-3e65111 directors so that going to substrate.dev/rustdocs/pre-v2.0-3e65111 automatically redirects to substrate.dev/rustdocs/pre-v2.0-3e65111/sc_service/index.html